### PR TITLE
[Patch] Flexbox padding for .explanator

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -181,6 +181,11 @@ header .header-box>.explanator>.title {
     display: flex;
     font-size: 2em;
     font-weight: 500;
+    flex: 1 0;
+}
+
+header .header-box>.explanator>.content {
+    flex: 3 0;
 }
 
 header .header-box>.explanator>.content>p {


### PR DESCRIPTION
The current explanatory section will break in certain languages, and this PR aims to fix that word-break situation by using the already-styled flexbox.

The following commit patches the issue described above:
- 🖼 fix: flexbox auto padding for explainatory subtitle (lifehome/Telegram-Limits@bc7b16d5b9814358b112f2029e5682b3f8a20e59)