### PR TITLE
Can see 10 search resuts on Android. Closes #188

### DIFF
--- a/localization/en/data.json
+++ b/localization/en/data.json
@@ -440,7 +440,7 @@
       "global_search": {
         "name": "Global search results",
         "hint": "",
-        "text": "up to 10 items; up to 3 for Android"
+        "text": "up to 10 items"
       },
       "global_search_min_query": {
         "name": "Minimal query length",


### PR DESCRIPTION
[Global search results can be more than 3 in number on Android now](https://github.com/tginfo/Telegram-Limits/issues/188) .