### PR TITLE
fix: issue in German translation for read receipts

### DIFF
--- a/localization/de-DE/data.json
+++ b/localization/de-DE/data.json
@@ -160,7 +160,7 @@
       "read_receipts_availability": {
         "name": "Verfügbarkeit von Lesebestätigungen",
         "hint": "",
-        "text": "für Chats mit mindestens 100 Mitgliedern, die Liste der Nutzer ist nur für den Nutzer verfügbar, der die Nachricht gesendet hat"
+        "text": "für Chats mit bis zu 100 Mitgliedern. Die Liste der Nutzer ist nur für den Nutzer verfügbar, der die Nachricht gesendet hat"
       },
       "read_receipts_lifetime": {
         "name": "Anzeigedauer von Lesebestätigungen",


### PR DESCRIPTION
The German translation said that read receipts are available for chats with 100 members or more. I changed it to "up to 100".